### PR TITLE
Extend error handling when we can't properly initialize a device

### DIFF
--- a/cli.cpp
+++ b/cli.cpp
@@ -53,6 +53,9 @@ int main() {
 		}
 		dev_i++;
 	}
+	if (dev_i == 0) {
+		return 1;
+	}
 	for (auto i: session->m_devices) {
 		session->configure(i->get_default_rate());
 	}

--- a/libsmu.hpp
+++ b/libsmu.hpp
@@ -113,8 +113,8 @@ protected:
 	virtual void cancel() = 0;
 
 	Session* const m_session;
-	libusb_device* const m_device;
-	libusb_device_handle* m_usb;
+	libusb_device* const m_device = NULL;
+	libusb_device_handle* m_usb = NULL;
 
 	// State owned by USB thread
 	sample_t m_requested_sampleno;

--- a/session.cpp
+++ b/session.cpp
@@ -151,7 +151,7 @@ shared_ptr<Device> Session::probe_device(libusb_device* device) {
 			libusb_get_string_descriptor_ascii(dev->m_usb, desc.iSerialNumber, (unsigned char*)&dev->serial_num, 32);
 			return dev;
 		} else {
-			cerr << "Error initializing device" << endl;
+			perror("Error initializing device");
 		}
 	}
 	return NULL;

--- a/session.cpp
+++ b/session.cpp
@@ -286,8 +286,10 @@ int Device::init() {
 
 // generic device teardown - libusb_close
 Device::~Device() {
-	libusb_close(m_usb);
-	libusb_unref_device(m_device);
+	if (m_usb)
+		libusb_close(m_usb);
+	if (m_device)
+		libusb_unref_device(m_device);
 }
 
 // generic implementation of ctrl_transfers


### PR DESCRIPTION
I was messing around and noticed it segfaulted when I didn't have the proper USB permissions. With these fixes it should at least provide users more notice of what they're doing wrong instead of segfaulting.

I should also note I was able to segfault pixelpulse2 somewhat consistently by shorting the 5V pin, but haven't tracked down a fix for that yet. Probably something similar though with usb device handling on corner error conditions. 