### PR TITLE
don't try to access device when probing failed

### DIFF
--- a/session.cpp
+++ b/session.cpp
@@ -65,9 +65,9 @@ Session::~Session() {
 // callback for device attach events
 void Session::attached(libusb_device *device) {
 	shared_ptr<Device> dev = probe_device(device);
-	m_available_devices.push_back(dev);
-	cerr << "Session::attached ser: " << dev->serial() << endl;
 	if (dev) {
+		m_available_devices.push_back(dev);
+		cerr << "Session::attached ser: " << dev->serial() << endl;
 		if (this->m_hotplug_attach_callback) {
 			cerr << dev << endl;
 			this->m_hotplug_attach_callback(&*dev);


### PR DESCRIPTION
This avoids a segfault in pixelpulse2 when first starting the app and
then plugging in a device without full access permissions to it.