### PR TITLE
pysmu: add support for the stairstep output waveform

### DIFF
--- a/pysmu-proto.py
+++ b/pysmu-proto.py
@@ -66,10 +66,12 @@ class channel(object):
         return pysmu.set_output_wave(self.dev, self.chan, self.mode, 1, midpoint, peak, period, phase, duty_cycle)
     def sawtooth(self, midpoint, peak, period, phase):
         return pysmu.set_output_wave(self.dev, self.chan, self.mode, 2, midpoint, peak, period, phase, 42)
-    def sine(self, midpoint, peak, period, phase):
+    def stairstep(self, midpoint, peak, period, phase):
         return pysmu.set_output_wave(self.dev, self.chan, self.mode, 3, midpoint, peak, period, phase, 42)
-    def triangle(self, midpoint, peak, period, phase):
+    def sine(self, midpoint, peak, period, phase):
         return pysmu.set_output_wave(self.dev, self.chan, self.mode, 4, midpoint, peak, period, phase, 42)
+    def triangle(self, midpoint, peak, period, phase):
+        return pysmu.set_output_wave(self.dev, self.chan, self.mode, 5, midpoint, peak, period, phase, 42)
 
     def __repr__(self):
         return 'Dev: '+str(self.dev)+'\nChan: '+str(self.chan)+'\nSignals: '+str(self.signals)

--- a/pysmu.cpp
+++ b/pysmu.cpp
@@ -139,6 +139,8 @@ extern "C" {
                     sgnl->source_square(val1, val2, period, duty, phase);
                 if (wave == SRC_SAWTOOTH)
                     sgnl->source_sawtooth(val1, val2, period, phase);
+                if (wave == SRC_STAIRSTEP)
+                    sgnl->source_stairstep(val1, val2, period, phase);
                 if (wave == SRC_TRIANGLE)
                     sgnl->source_triangle(val1, val2, period, phase);
                 if (wave == SRC_SINE)


### PR DESCRIPTION
Also fixes the ordering of the output wave enum usage to match what's
currently defined for the backend.